### PR TITLE
fix: reduce chinese budget to 65

### DIFF
--- a/word_search/application/use_cases.py
+++ b/word_search/application/use_cases.py
@@ -11,7 +11,7 @@ from word_search.infrastructure import build_pdf, get_words_for_type
 PUZZLE_CONFIG = {
     "letters": {"min_length": 3, "max_length": 7, "budget": 70},
     "numbers": {"min_length": 3, "max_length": 6, "budget": 50},
-    "chinese": {"min_length": 2, "max_length": 6, "budget": 70},
+    "chinese": {"min_length": 2, "max_length": 6, "budget": 65},
     "shapes": {"min_length": 2, "max_length": 4, "budget": 50},
 }
 


### PR DESCRIPTION
## Summary
- Reduce Chinese puzzle budget from 70 to 65 to prevent overflow to 2 pages
- Ensures exactly 200 pages per puzzle type